### PR TITLE
fix: dont save window state twice if the same window name is provided…

### DIFF
--- a/Source/SpiderEye.Linux/GtkWindow.cs
+++ b/Source/SpiderEye.Linux/GtkWindow.cs
@@ -247,6 +247,12 @@ namespace SpiderEye.Linux
 
         public void RestoreAndAutoSavePosition(string name, Size defaultSize)
         {
+            if (name == autosaveName)
+            {
+                // The position for the name is already set
+                return;
+            }
+
             if (autosaveName != null)
             {
                 // Save information from previous name

--- a/Source/SpiderEye.Windows/WinFormsWindow.cs
+++ b/Source/SpiderEye.Windows/WinFormsWindow.cs
@@ -183,6 +183,12 @@ namespace SpiderEye.Windows
 
         public void RestoreAndAutoSavePosition(string name, Size defaultSize)
         {
+            if (name == autosaveName)
+            {
+                // The position for the name is already set
+                return;
+            }
+
             if (autosaveName != null)
             {
                 // Save information from previous name


### PR DESCRIPTION
… again